### PR TITLE
Fixed spins in network read operations when the socket connection is broken

### DIFF
--- a/Netimobiledevice/Lockdown/ServiceConnection.cs
+++ b/Netimobiledevice/Lockdown/ServiceConnection.cs
@@ -95,6 +95,9 @@ namespace Netimobiledevice.Lockdown
                 }
 
                 int bytesRead = networkStream.Read(receiveBuffer, 0, readSize);
+                if (bytesRead == 0) { // If we don't get any bytes, the network connection was broken
+                    break;
+                }
                 totalBytesRead += bytesRead;
 
                 buffer.AddRange(receiveBuffer.Take(bytesRead));
@@ -134,6 +137,9 @@ namespace Netimobiledevice.Lockdown
                         throw new TimeoutException("Timeout waiting for message from service");
                     }
                     bytesRead = await result;
+                    if (bytesRead == 0) { // If we don't get any bytes, the network connection was broken
+                        break;
+                    }
                 }
                 else {
                     bytesRead = await networkStream.ReadAsync(receiveBuffer.AsMemory(0, readSize), cancellationToken);


### PR DESCRIPTION
Read and ReadAsync return 0 if the socket connection fails, but doesn't throw any errors when that happens.