### PR TITLE
Various fixes

### DIFF
--- a/Netimobiledevice/Backup/DeviceBackup.cs
+++ b/Netimobiledevice/Backup/DeviceBackup.cs
@@ -513,9 +513,11 @@ namespace Netimobiledevice.Backup
                 }
             }
 
-            // Check if the execution arrived here due to a device disconnection.
-            if (terminatingException == null || !Usbmux.IsDeviceConnected(LockdownClient.Udid)) {
-                throw new DeviceDisconnectedException();
+            // Check if the execution arrived here due to a device disconnection, but skip if the scan has finished
+            if (!IsFinished) {
+                if (terminatingException == null || !Usbmux.IsDeviceConnected(LockdownClient.Udid)) {
+                    throw new DeviceDisconnectedException();
+                }
             }
 
             LockdownClient.Logger.LogInformation($"Finished message loop. Cancelling = {IsCancelling}, Finished = {IsFinished}, Errored = {terminatingException != null}");

--- a/Netimobiledevice/Plist/DateNode.cs
+++ b/Netimobiledevice/Plist/DateNode.cs
@@ -76,7 +76,7 @@ namespace Netimobiledevice.Plist
         /// </returns>
         internal override string ToXmlString()
         {
-            return Value.ToUniversalTime().ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.ffffffZ", CultureInfo.InvariantCulture);
+            return Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.ffffffZ", CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace Netimobiledevice.Plist
         {
             TimeSpan ts = Value - MacEpoch;
             byte[] buf = EndianBitConverter.BigEndian.GetBytes(ts.TotalSeconds);
-            stream.Write(buf, 0, buf.Length);
+            stream.Write(buf);
         }
     }
 }

--- a/Netimobiledevice/Plist/DateNode.cs
+++ b/Netimobiledevice/Plist/DateNode.cs
@@ -76,7 +76,7 @@ namespace Netimobiledevice.Plist
         /// </returns>
         internal override string ToXmlString()
         {
-            return Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ss.ffffffZ", CultureInfo.InvariantCulture);
+            return Value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ssZ", CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/Netimobiledevice/Plist/PlistType.cs
+++ b/Netimobiledevice/Plist/PlistType.cs
@@ -58,7 +58,7 @@ namespace Netimobiledevice.Plist
         /// <summary>
         /// UTF16 String node type.
         /// </summary>
-        [EnumMember(Value = "string")]
+        [EnumMember(Value = "ustring")]
         UString = 0x60,
         /// <summary>
         /// UID node type.

--- a/Netimobiledevice/Plist/StringNode.cs
+++ b/Netimobiledevice/Plist/StringNode.cs
@@ -120,9 +120,7 @@ namespace Netimobiledevice.Plist
 
         internal override void WriteXml(XmlWriter writer)
         {
-            // Use "string" tag for single-byte and "ustring" for UTF-16 characters
-            string tag = IsUtf16 ? "ustring" : "string";
-            writer.WriteStartElement(tag);
+            writer.WriteStartElement("string");
             writer.WriteValue(ToXmlString());
             writer.WriteEndElement();
         }

--- a/NetimobiledeviceTest/Plist/DateNodeTests.cs
+++ b/NetimobiledeviceTest/Plist/DateNodeTests.cs
@@ -64,4 +64,14 @@ public class DateNodeTests
         cultureInfo.DateTimeFormat.Calendar = new UmAlQuraCalendar();
         ExecuteWithCulture(() => DateHandlesArabicCulture(), cultureInfo);
     }
+
+    [TestMethod]
+    public void XmlStringIsValid()
+    {
+        DateTime currentTime = new DateTime(2005, 06, 17, 18, 19, 21, 222, DateTimeKind.Utc);
+        DateNode node = new DateNode(currentTime);
+
+        string xmlString = node.ToXmlString();
+        Assert.AreEqual("2005-06-17T18:19:21Z", xmlString);
+    }
 }

--- a/NetimobiledeviceTest/Plist/DateNodeTests.cs
+++ b/NetimobiledeviceTest/Plist/DateNodeTests.cs
@@ -48,12 +48,12 @@ public class DateNodeTests
     {
         DateTime originalDateTime = new DateTime(2015, 9, 30, 0, 0, 0, DateTimeKind.Utc);
         DateNode node = new DateNode(originalDateTime);
-        Assert.AreEqual("2015-09-30T00:00:00.000000Z", node.ToXmlString());
+        Assert.AreEqual("2015-09-30T00:00:00Z", node.ToXmlString());
         Assert.AreEqual(originalDateTime, node.Value);
 
         DateTime alternativeDateTime = new DateTime(455874381151831020, DateTimeKind.Utc);
         DateNode alternativeNode = new DateNode(alternativeDateTime);
-        Assert.AreEqual("1445-08-11T09:15:15.183102Z", alternativeNode.ToXmlString());
+        Assert.AreEqual("1445-08-11T09:15:15Z", alternativeNode.ToXmlString());
         Assert.AreEqual(alternativeDateTime, alternativeNode.Value);
     }
 

--- a/NetimobiledeviceTest/Plist/DateNodeTests.cs
+++ b/NetimobiledeviceTest/Plist/DateNodeTests.cs
@@ -6,7 +6,7 @@ namespace NetimobiledeviceTest.Plist;
 [TestClass]
 public class DateNodeTests
 {
-    private void ExecuteWithCulture(Action methodFunc, CultureInfo culture)
+    private static void ExecuteWithCulture(Action methodFunc, CultureInfo culture)
     {
         var thread = new Thread(() => {
             methodFunc();
@@ -44,14 +44,14 @@ public class DateNodeTests
         Assert.AreEqual(currentTime, value);
     }
 
-    public void DateHandlesArabicCulture()
+    public static void DateHandlesArabicCulture()
     {
-        DateTime originalDateTime = new DateTime(2015, 9, 30);
+        DateTime originalDateTime = new DateTime(2015, 9, 30, 0, 0, 0, DateTimeKind.Utc);
         DateNode node = new DateNode(originalDateTime);
         Assert.AreEqual("2015-09-30T00:00:00.000000Z", node.ToXmlString());
         Assert.AreEqual(originalDateTime, node.Value);
 
-        DateTime alternativeDateTime = new DateTime(455874381151831020);
+        DateTime alternativeDateTime = new DateTime(455874381151831020, DateTimeKind.Utc);
         DateNode alternativeNode = new DateNode(alternativeDateTime);
         Assert.AreEqual("1445-08-11T09:15:15.183102Z", alternativeNode.ToXmlString());
         Assert.AreEqual(alternativeDateTime, alternativeNode.Value);

--- a/NetimobiledeviceTest/Plist/XmlReaderTests.cs
+++ b/NetimobiledeviceTest/Plist/XmlReaderTests.cs
@@ -83,5 +83,70 @@ public class XmlReaderTests
             }
         }
     }
+
+    [TestMethod]
+    public void HandleEmptyDictionary()
+    {
+        using (Stream stream = TestFileHelper.GetTestFileStream("TestFiles/EmptyDictionaryXml.plist")) {
+            try {
+                DictionaryNode rootNode = PropertyList.Load(stream).AsDictionaryNode();
+
+                Assert.IsNotNull(rootNode);
+                Assert.AreEqual(4, rootNode.Count);
+
+                // An empty dictionary in the root
+                Assert.IsInstanceOfType<DictionaryNode>(rootNode["{}"]);
+                DictionaryNode dict = rootNode["{}"].AsDictionaryNode();
+
+                Assert.IsNotNull(dict);
+                Assert.AreEqual(0, dict.Count);
+
+                // an empty dictionary that is nested
+                dict = rootNode["{\"foo\":{\"bar\":{\"quux\":{}}}}"].AsDictionaryNode();
+                Assert.IsNotNull(dict);
+
+                dict = dict["foo"].AsDictionaryNode();
+                Assert.IsNotNull(dict);
+
+                dict = dict["bar"].AsDictionaryNode();
+                Assert.IsNotNull(dict);
+
+                dict = dict["quux"].AsDictionaryNode();
+                Assert.IsNotNull(dict);
+
+                Assert.AreEqual(0, dict.Count);
+            }
+            catch (PlistFormatException ex) {
+                Assert.Fail(ex.Message);
+            }
+        }
+    }
+
+
+    [TestMethod]
+    public void HandleBooleans()
+    {
+        using (Stream stream = TestFileHelper.GetTestFileStream("TestFiles/BooleansXml.plist")) {
+            try {
+                DictionaryNode rootNode = PropertyList.Load(stream).AsDictionaryNode();
+
+                Assert.IsNotNull(rootNode);
+                Assert.AreEqual(2, rootNode.Count);
+
+                // true node
+                BooleanNode node = rootNode["foo"].AsBooleanNode();
+                Assert.IsNotNull(node);
+                Assert.IsTrue(node.Value);
+
+                // false node
+                node = rootNode["bar"].AsBooleanNode();
+                Assert.IsNotNull(node);
+                Assert.IsFalse(node.Value);
+            }
+            catch (PlistFormatException ex) {
+                Assert.Fail(ex.Message);
+            }
+        }
+    }
 }
 

--- a/NetimobiledeviceTest/Plist/XmlWriterTests.cs
+++ b/NetimobiledeviceTest/Plist/XmlWriterTests.cs
@@ -123,7 +123,7 @@ public class XmlWriterTests
             // check that boolean was written out without a space per spec
             using (var reader = new StreamReader(outStream)) {
                 string contents = reader.ReadToEnd();
-                Assert.IsTrue(contents.Contains($"<ustring>{utf16value}</ustring>"));
+                Assert.IsTrue(contents.Contains($"<string>{utf16value}</string>"));
             }
         }
     }

--- a/NetimobiledeviceTest/Plist/XmlWriterTests.cs
+++ b/NetimobiledeviceTest/Plist/XmlWriterTests.cs
@@ -159,4 +159,20 @@ public class XmlWriterTests
         Assert.AreEqual(messageFilter, (int) reReadNode["MessageFilter"].AsIntegerNode().Value);
         Assert.AreEqual(pid, (int) reReadNode["Pid"].AsIntegerNode().Value);
     }
+
+    [TestMethod]
+    public void HandlesUniqueCharacters()
+    {
+        ArrayNode array = new() {
+            new StringNode("&"),
+            new StringNode("<"),
+            new StringNode(">")
+        };
+
+        byte[] plistBytes = PropertyList.SaveAsByteArray(array, PlistFormat.Xml);
+        ArrayNode reReadArr = PropertyList.LoadFromByteArray(plistBytes).AsArrayNode();
+        Assert.AreEqual(array[0].AsStringNode().Value, reReadArr[0].AsStringNode().Value);
+        Assert.AreEqual(array[1].AsStringNode().Value, reReadArr[1].AsStringNode().Value);
+        Assert.AreEqual(array[2].AsStringNode().Value, reReadArr[2].AsStringNode().Value);
+    }
 }

--- a/NetimobiledeviceTest/TestFiles/BooleansXml.plist
+++ b/NetimobiledeviceTest/TestFiles/BooleansXml.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>foo</key>
+	<true/>
+	<key>bar</key>
+	<false/>
+</dict>
+</plist>

--- a/NetimobiledeviceTest/TestFiles/EmptyDictionaryXml.plist
+++ b/NetimobiledeviceTest/TestFiles/EmptyDictionaryXml.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>{}</key>
+    <dict/>
+
+    <key>{"foo":"bar"}</key>
+    <dict>
+        <key>foo</key>
+        <string>bar</string>
+    </dict>
+
+    <key>{"foo":{"bar":"quux"}}</key>
+    <dict>
+        <key>foo</key>
+        <dict>
+            <key>bar</key>
+            <string>quux</string>
+        </dict>
+    </dict>
+
+    <key>{"foo":{"bar":{"quux":{}}}}</key>
+    <dict>
+        <key>foo</key>
+        <dict>
+            <key>bar</key>
+            <dict>
+                <key>quux</key>
+                <dict/>
+            </dict>
+        </dict>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Fixes a couple of issues:

1. Occasionally you would get a disconnect exception when a backup has finished and the phone temporarily thinks it is diconected.
2. Always use UTF8 encoding for xml string output as plist viewers like plist Editor Pro didn't like having UTF-16 strings.
3. Fix the test case for arabic calendars
4. Remove the conversion to universal time for XML string output
5. Fix XML string output for Date plist types to not include milliseconds as Python's plistlib does not like it having this included.