### PR TITLE
Make GetFileInfo in the AfcService available for everyone

### DIFF
--- a/Netimobiledevice/Afc/AfcService.cs
+++ b/Netimobiledevice/Afc/AfcService.cs
@@ -103,7 +103,7 @@ namespace Netimobiledevice.Afc
             return data.ToArray();
         }
 
-        private DictionaryNode GetFileInfo(string filename)
+        public DictionaryNode GetFileInfo(string filename)
         {
             Dictionary<string, string> stat;
             try {

--- a/Netimobiledevice/Netimobiledevice.csproj
+++ b/Netimobiledevice/Netimobiledevice.csproj
@@ -20,7 +20,7 @@
 		<RepositoryUrl>https://github.com/artehe/Netimobiledevice</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<Title>$(AssemblyName)</Title>
-		<Version>1.1.0</Version>
+		<Version>1.1.1</Version>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Hey,
sometimes it's helpfull to just see the file size, creation date and so without completely transferring the file. Therefore it would be nice to make the GetFileInfo function public. 
Best regards
Daniel