### PR TITLE
Improve ssl service connection startin

### DIFF
--- a/Netimobiledevice/Lockdown/Pairing/CertificateGenerator.cs
+++ b/Netimobiledevice/Lockdown/Pairing/CertificateGenerator.cs
@@ -3,7 +3,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
-namespace Netimobiledevice.Lockdown
+namespace Netimobiledevice.Lockdown.Pairing
 {
     public static class CertificateGenerator
     {

--- a/Netimobiledevice/Lockdown/ServiceConnection.cs
+++ b/Netimobiledevice/Lockdown/ServiceConnection.cs
@@ -270,14 +270,9 @@ namespace Netimobiledevice.Lockdown
 
         public void StartSSL(byte[] certData, byte[] privateKeyData)
         {
-            X509Certificate2 cert;
-            string tmpPath = Path.GetTempFileName();
-            using (FileStream fs = new FileStream(tmpPath, FileMode.OpenOrCreate, FileAccess.ReadWrite)) {
-                fs.Write(certData);
-                fs.Write(Encoding.UTF8.GetBytes("\n"));
-                fs.Write(privateKeyData);
-            }
-            cert = X509Certificate2.CreateFromPemFile(tmpPath);
+            string certText = Encoding.UTF8.GetString(certData);
+            string privateKeyText = Encoding.UTF8.GetString(privateKeyData);
+            X509Certificate2 cert = X509Certificate2.CreateFromPem(certText, privateKeyText);
 
             networkStream.Flush();
 
@@ -285,7 +280,7 @@ namespace Netimobiledevice.Lockdown
             try {
                 // NOTE: For some reason we need to re-export and then import the cert again ¯\_(ツ)_/¯
                 // see this for more details: https://github.com/dotnet/runtime/issues/45680
-                sslStream.AuthenticateAsClient(string.Empty, new X509CertificateCollection() { new X509Certificate2(cert.Export(X509ContentType.Pkcs12)) }, SslProtocols.None, false);
+                sslStream.AuthenticateAsClient(string.Empty, [new X509Certificate2(cert.Export(X509ContentType.Pkcs12))], SslProtocols.None, false);
             }
             catch (AuthenticationException ex) {
                 logger.LogError(ex, "SSL authentication failed");


### PR DESCRIPTION
Improves service connection SSL starting performance by removing unnecessary file write and read and just converting the data to strings to import as a certificate

Also moves the Certificate generator to the Pairing namespace.