### PR TITLE
Improve backup performance by limiting file open calls

### DIFF
--- a/Netimobiledevice/Backup/BackupFile.cs
+++ b/Netimobiledevice/Backup/BackupFile.cs
@@ -22,6 +22,10 @@ namespace Netimobiledevice.Backup
         /// </summary>
         public string LocalPath { get; }
 
+        public long FileSize { get; set; } = 0;
+        
+        public long ExpectedFileSize { get; set; } = 0;
+
         /// <summary>
         /// Creates an instance of a BackupFile
         /// </summary>
@@ -33,6 +37,15 @@ namespace Netimobiledevice.Backup
             DevicePath = devicePath;
             BackupPath = backupPath;
             LocalPath = Path.Combine(backupDirectory, backupPath);
+            Empty = false;
         }
+        public BackupFile()
+        {
+            DevicePath = "";
+            BackupPath = "";
+            LocalPath = "";
+            Empty = true;
+        }
+        public bool Empty { get; }
     }
 }

--- a/Netimobiledevice/Backup/BackupFileErrorEventArgs.cs
+++ b/Netimobiledevice/Backup/BackupFileErrorEventArgs.cs
@@ -10,6 +10,10 @@
         /// </summary>
         public bool Cancel { get; set; }
 
-        public BackupFileErrorEventArgs(BackupFile file) : base(file) { }
+        public BackupFileErrorEventArgs(BackupFile file, string details) : base(file) // MEF: Added details
+        {
+            Details = details;
+        }
+        public string Details { get; set; }
     }
 }

--- a/Netimobiledevice/Backup/BackupFileEventArgs.cs
+++ b/Netimobiledevice/Backup/BackupFileEventArgs.cs
@@ -16,14 +16,18 @@ namespace Netimobiledevice.Backup
         /// </summary>
         public byte[] Data { get; }
 
+        public long FileSize { get; }
         /// <summary>
         /// Creates an instance of the BackupFileEventArgs class.
         /// </summary>
         /// <param name="file">The BackupFile related to the event.</param>
-        public BackupFileEventArgs(BackupFile file)
+        /// <param name="fileSize"></param>
+        public BackupFileEventArgs(BackupFile file, long fileSize = 0)
         {
             File = file;
             Data = Array.Empty<byte>();
+            FileSize = fileSize;
+            
         }
 
         /// <summary>

--- a/Netimobiledevice/Backup/BackupFileEventArgs.cs
+++ b/Netimobiledevice/Backup/BackupFileEventArgs.cs
@@ -16,18 +16,15 @@ namespace Netimobiledevice.Backup
         /// </summary>
         public byte[] Data { get; }
 
-        public long FileSize { get; }
         /// <summary>
         /// Creates an instance of the BackupFileEventArgs class.
         /// </summary>
         /// <param name="file">The BackupFile related to the event.</param>
         /// <param name="fileSize"></param>
-        public BackupFileEventArgs(BackupFile file, long fileSize = 0)
+        public BackupFileEventArgs(BackupFile file)
         {
             File = file;
             Data = Array.Empty<byte>();
-            FileSize = fileSize;
-            
         }
 
         /// <summary>

--- a/Netimobiledevice/Backup/StatusEventArgs.cs
+++ b/Netimobiledevice/Backup/StatusEventArgs.cs
@@ -13,12 +13,19 @@ namespace Netimobiledevice.Backup
         public string Message { get; }
 
         /// <summary>
+        /// The full status details
+        /// </summary>
+        public BackupStatus? Status { get; }
+
+        /// <summary>
         /// Creates an instance of the StatusEventArgs class.
         /// </summary>
         /// <param name="message">The status message.</param>
-        public StatusEventArgs(string message)
+        /// <param name="status">The BackupStatus object containing all the details</param>
+        public StatusEventArgs(string message, BackupStatus? status = null)
         {
             Message = message;
+            Status = status;
         }
     }
 }

--- a/Netimobiledevice/DeviceLink/DetailedErrorEventArgs.cs
+++ b/Netimobiledevice/DeviceLink/DetailedErrorEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.IO;
+
+namespace Netimobiledevice.DeviceLink
+{
+
+    public class DetailedErrorEventArgs : ErrorEventArgs
+    {
+        public string Details { get; set; }
+        
+        public DetailedErrorEventArgs(Exception exception, string details) : base(exception) {
+            Details = details;
+        }
+    }
+
+}

--- a/Netimobiledevice/DeviceLink/DeviceLinkService.cs
+++ b/Netimobiledevice/DeviceLink/DeviceLinkService.cs
@@ -698,7 +698,7 @@ namespace Netimobiledevice.DeviceLink
                 if (backupFile != null) {
                     backupFile.ExpectedFileSize = backupTotalSize;
                     _logger.LogDebug("Receiving file {BackupPath}", backupFile.BackupPath);
-                    BeforeReceivingFile?.Invoke(this, new BackupFileEventArgs(backupFile, backupTotalSize));
+                    BeforeReceivingFile?.Invoke(this, new BackupFileEventArgs(backupFile));
                     ResultCode code = await ReceiveFile(backupFile, cancellationToken).ConfigureAwait(false);
                     if (code == ResultCode.Success) {
                         OnFileReceived(backupFile);


### PR DESCRIPTION
Added some timing measurements
Added details to some event handlers

We saw backup performance improve by between 40-50% with these changes in our project. Opening a file for each block of data to write, and then closing it, took a significant amount of time, even on SSD drives.