### PR TITLE
Added an option to get a signed value from the Integer node,

### DIFF
--- a/Netimobiledevice/Plist/IntegerNode.cs
+++ b/Netimobiledevice/Plist/IntegerNode.cs
@@ -44,6 +44,8 @@ namespace Netimobiledevice.Plist
 
         public bool Unsigned { get; private set; }
 
+        public long SignedValue => (long) Value;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="IntegerNode"/> class.
         /// </summary>


### PR DESCRIPTION
Sometimes, with file errors, the value can be negative.

Specifically, we used this when handling SendFileError event - I'm not sure that event exists any more? Also, I know that you could cast the Value when you get it, but I like not having to do that.