### PR TITLE
Handle file tranfer error ignoring better

### DIFF
--- a/NetimobiledeviceDemo/Program.cs
+++ b/NetimobiledeviceDemo/Program.cs
@@ -63,7 +63,7 @@ public class Program
                 mb2.Status += BackupJob_Status;
                 mb2.Started += BackupJob_Started;
 
-                await mb2.Backup(true, "backups", tokenSource.Token);
+                await mb2.Backup(true, false, "backups", tokenSource.Token);
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ using (UsbmuxLockdownClient lockdown = MobileDevice.CreateUsingUsbmux("60653a518
         mb2.Status += BackupJob_Status;
         mb2.Started += BackupJob_Started;
 
-        await mb2.Backup(true, "backups", tokenSource.Token);
+        await mb2.Backup(true, true, "backups", tokenSource.Token);
     }
 }
 ```
@@ -123,8 +123,8 @@ using Microsoft.Extensions.Logging;
 
 using ILoggerFactory factory = LoggerFactory.Create(builder => builder.SetMinimumLevel(LogLevel.Debug).AddConsole());
 using (LockdownClient lockdown = MobileDevice.CreateUsingUsbmux(testDevice?.Serial ?? string.Empty, logger: factory.CreateLogger("Netimobiledevice"))) {
-    using (DeviceBackup backupJob = new DeviceBackup(lockdown, path)) {
-        await backupJob.Start(tokenSource.Token);
+    using (Mobilebackup2Service mb2 = new Mobilebackup2Service(lockdown)) {
+        await mb2.Backup(true, true, "backups", tokenSource.Token);
     }
 }
 ```


### PR DESCRIPTION
Rather than just ignoring the error when we don't subscribe to the event I think using a parameter passed to the backup function is a better method.