### PR TITLE
Change NotificationProxy registration

### DIFF
--- a/Netimobiledevice/Backup/BackupLock.cs
+++ b/Netimobiledevice/Backup/BackupLock.cs
@@ -32,10 +32,10 @@ namespace Netimobiledevice.Backup
 
         public async Task AquireBackupLock(CancellationToken cancellationToken)
         {
-            _np.Post(SendableNotificaton.SyncWillStart);
+            await _np.PostAsync(SendableNotificaton.SyncWillStart).ConfigureAwait(false);
             _syncLockFileHandle = await _afc.FileOpen(SYNC_LOCK_FILE_PATH, cancellationToken, AfcFileOpenMode.ReadWrite).ConfigureAwait(false);
             if (_syncLockFileHandle > 0) {
-                _np.Post(SendableNotificaton.SyncLockRequest);
+                await _np.PostAsync(SendableNotificaton.SyncLockRequest).ConfigureAwait(false);
 
                 bool lockAquired = false;
                 for (int i = 0; i < 50; i++) {
@@ -59,7 +59,7 @@ namespace Netimobiledevice.Backup
                 }
 
                 if (lockAquired) {
-                    _np.Post(SendableNotificaton.SyncDidStart);
+                    await _np.PostAsync(SendableNotificaton.SyncDidStart).ConfigureAwait(false);
                 }
             }
             else {

--- a/Netimobiledevice/Backup/Mobilebackup2Service.cs
+++ b/Netimobiledevice/Backup/Mobilebackup2Service.cs
@@ -370,9 +370,9 @@ namespace Netimobiledevice.Backup
 
                 using (NotificationProxyService np = new NotificationProxyService(this.Lockdown)) {
                     np.ReceivedNotification += NotificationProxy_ReceivedNotification;
-                    np.ObserveNotification(ReceivableNotification.SyncCancelRequest);
-                    np.ObserveNotification(ReceivableNotification.LocalAuthenticationUiPresented);
-                    np.ObserveNotification(ReceivableNotification.LocalAuthenticationUiDismissed);
+                    await np.ObserveNotificationAsync(ReceivableNotification.SyncCancelRequest).ConfigureAwait(false);
+                    await np.ObserveNotificationAsync(ReceivableNotification.LocalAuthenticationUiPresented).ConfigureAwait(false);
+                    await np.ObserveNotificationAsync(ReceivableNotification.LocalAuthenticationUiDismissed).ConfigureAwait(false);
 
                     using (AfcService afc = new AfcService(this.Lockdown)) {
                         using (BackupLock backupLock = new BackupLock(afc, np)) {

--- a/Netimobiledevice/Lockdown/LockdownClient.cs
+++ b/Netimobiledevice/Lockdown/LockdownClient.cs
@@ -432,7 +432,8 @@ namespace Netimobiledevice.Lockdown
         public virtual async Task<bool> PairAsync(IProgress<PairingState> progress, CancellationToken cancellationToken)
         {
             using (NotificationProxyService np = new NotificationProxyService(this, true)) {
-                np.ObserveNotification(ReceivableNotification.RequestPair);
+                await np.ObserveNotificationAsync(ReceivableNotification.RequestPair).ConfigureAwait(false);
+
                 LockdownError? err = null;
                 PairingState? lastPairingReport = null;
                 while (!cancellationToken.IsCancellationRequested) {

--- a/Netimobiledevice/Netimobiledevice.csproj
+++ b/Netimobiledevice/Netimobiledevice.csproj
@@ -21,7 +21,7 @@
 		<RepositoryUrl>https://github.com/artehe/Netimobiledevice</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<Title>$(AssemblyName)</Title>
-		<Version>2.3.0</Version>
+		<Version>2.4.0</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Netimobiledevice/NotificationProxy/NotificationProxyService.cs
+++ b/Netimobiledevice/NotificationProxy/NotificationProxyService.cs
@@ -128,30 +128,6 @@ namespace Netimobiledevice.NotificationProxy
         }
 
         /// <summary>
-        /// Inform the iOS device to send a notification on the specified event
-        /// </summary>
-        /// <param name="name"></param>
-        private void RegisterNotification(string notification)
-        {
-            DictionaryNode request = new DictionaryNode() {
-                { "Command", new StringNode("ObserveNotification") },
-                { "Name", new StringNode(notification) }
-            };
-
-            serviceLockSemaphoreSlim.Wait();
-            try {
-                Service.SendPlist(request);
-            }
-            finally {
-                serviceLockSemaphoreSlim.Release();
-            }
-
-            if (!notificationListener.IsBusy) {
-                notificationListener.RunWorkerAsync();
-            }
-        }
-
-        /// <summary>
         /// Posts the specified notification.
         /// </summary>
         /// <param name="notification">The notification to post.</param>
@@ -172,12 +148,71 @@ namespace Netimobiledevice.NotificationProxy
         }
 
         /// <summary>
+        /// Posts the specified notification.
+        /// </summary>
+        /// <param name="notification">The notification to post.</param>
+        public async Task PostAsync(string notification)
+        {
+            DictionaryNode msg = new DictionaryNode() {
+                { "Command", new StringNode("PostNotification") },
+                { "Name", new StringNode(notification) }
+            };
+
+            await serviceLockSemaphoreSlim.WaitAsync().ConfigureAwait(false);
+            try {
+                await Service.SendPlistAsync(msg).ConfigureAwait(false);
+            }
+            finally {
+                serviceLockSemaphoreSlim.Release();
+            }
+        }
+
+        /// <summary>
         /// Inform the device of the notification we want to observe.
         /// </summary>
         /// <param name="notification"></param>
         public void ObserveNotification(string notification)
         {
-            RegisterNotification(notification);
+            DictionaryNode request = new DictionaryNode() {
+                { "Command", new StringNode("ObserveNotification") },
+                { "Name", new StringNode(notification) }
+            };
+
+            serviceLockSemaphoreSlim.Wait();
+            try {
+                Service.SendPlist(request);
+            }
+            finally {
+                serviceLockSemaphoreSlim.Release();
+            }
+
+            if (!notificationListener.IsBusy) {
+                notificationListener.RunWorkerAsync();
+            }
+        }
+
+        /// <summary>
+        /// Inform the device of the notification we want to observe.
+        /// </summary>
+        /// <param name="notification"></param>
+        public async Task ObserveNotificationAsync(string notification)
+        {
+            DictionaryNode request = new DictionaryNode() {
+                { "Command", new StringNode("ObserveNotification") },
+                { "Name", new StringNode(notification) }
+            };
+
+            await serviceLockSemaphoreSlim.WaitAsync().ConfigureAwait(false);
+            try {
+                await Service.SendPlistAsync(request).ConfigureAwait(false);
+            }
+            finally {
+                serviceLockSemaphoreSlim.Release();
+            }
+
+            if (!notificationListener.IsBusy) {
+                notificationListener.RunWorkerAsync();
+            }
         }
 
         /// <summary>

--- a/Netimobiledevice/NotificationProxy/ReceivableNotification.cs
+++ b/Netimobiledevice/NotificationProxy/ReceivableNotification.cs
@@ -3,31 +3,31 @@
     /// <summary>
     /// Device-To-Host (Receivable) notifications.
     /// </summary>
-    public enum ReceivableNotification
+    public static class ReceivableNotification
     {
-        SyncCancelRequest,
-        SyncSuspendRequst,
-        SyncResumeRequst,
-        PhoneNumberChanged,
-        DeviceNameChanged,
-        TimezoneChanged,
-        TrustedHostAttached,
-        HostDetached,
-        HostAttached,
-        RegistrationFailed,
-        ActivationState,
-        BrickState,
-        DiskUsageChanged,
-        DsDomainChanged,
-        AppInstalled,
-        AppUninstalled,
-        DeveloperImageMounted,
-        AttemptActivation,
-        ItdbprepDidEnd,
-        LanguageChanged,
-        AddressBookPreferenceChanged,
-        RequestPair,
-        LocalAuthenticationUiPresented,
-        LocalAuthenticationUiDismissed
+        public static string SyncCancelRequest => "com.apple.itunes-client.syncCancelRequest";
+        public static string SyncSuspendRequst => "com.apple.itunes-client.syncSuspendRequest";
+        public static string SyncResumeRequst => "com.apple.itunes-client.syncResumeRequest";
+        public static string PhoneNumberChanged => "com.apple.mobile.lockdown.phone_number_changed";
+        public static string DeviceNameChanged => "com.apple.mobile.lockdown.device_name_changed";
+        public static string TimezoneChanged => "com.apple.mobile.lockdown.timezone_changed";
+        public static string TrustedHostAttached => "com.apple.mobile.lockdown.trusted_host_attached";
+        public static string HostDetached => "com.apple.mobile.lockdown.host_detached";
+        public static string HostAttached => "com.apple.mobile.lockdown.host_attached";
+        public static string RegistrationFailed => "com.apple.mobile.lockdown.registration_failed";
+        public static string ActivationState => "com.apple.mobile.lockdown.activation_state";
+        public static string BrickState => "com.apple.mobile.lockdown.brick_state";
+        public static string DiskUsageChanged => "com.apple.mobile.lockdown.disk_usage_changed";
+        public static string DsDomainChanged => "com.apple.mobile.data_sync.domain_changed";
+        public static string AppInstalled => "com.apple.mobile.application_installed";
+        public static string AppUninstalled => "com.apple.mobile.application_uninstalled";
+        public static string DeveloperImageMounted => "com.apple.mobile.developer_image_mounted";
+        public static string AttemptActivation => "com.apple.springboard.attemptactivation";
+        public static string ItdbprepDidEnd => "com.apple.itdbprep.notification.didEnd";
+        public static string LanguageChanged => "com.apple.language.changed";
+        public static string AddressBookPreferenceChanged => "com.apple.AddressBook.PreferenceChanged";
+        public static string RequestPair => "com.apple.mobile.lockdown.request_pair";
+        public static string LocalAuthenticationUiPresented => "com.apple.LocalAuthentication.ui.presented";
+        public static string LocalAuthenticationUiDismissed => "com.apple.LocalAuthentication.ui.dismissed";
     }
 }

--- a/Netimobiledevice/NotificationProxy/ReceivedNotificationEventArgs.cs
+++ b/Netimobiledevice/NotificationProxy/ReceivedNotificationEventArgs.cs
@@ -5,26 +5,20 @@ namespace Netimobiledevice.NotificationProxy
     /// <summary>
     /// Class that contains event argument for <see cref="NotificationProxyService"/> events
     /// </summary>
-    public sealed class ReceivedNotificationEventArgs : EventArgs
+    /// <remarks>
+    /// Create the event args.
+    /// </remarks>
+    /// <param name="event">The receivable event type</param>
+    /// <param name="name">The event name</param>
+    public sealed class ReceivedNotificationEventArgs(string @event, string name) : EventArgs()
     {
         /// <summary>
         /// The type of the notification proxy event.
         /// </summary>
-        public ReceivableNotification Event { get; }
+        public string Event { get; } = @event;
         /// <summary>
         /// The name of the notification proxy event.
         /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// Create the event args.
-        /// </summary>
-        /// <param name="event">The receivable event type</param>
-        /// <param name="name">The event name</param>
-        public ReceivedNotificationEventArgs(ReceivableNotification @event, string name) : base()
-        {
-            Event = @event;
-            Name = name;
-        }
+        public string Name { get; } = name;
     }
 }

--- a/Netimobiledevice/NotificationProxy/SendableNotificaton.cs
+++ b/Netimobiledevice/NotificationProxy/SendableNotificaton.cs
@@ -3,23 +3,23 @@
     /// <summary>
     /// Host-To-Device (sendable) notifications.
     /// </summary>
-    public enum SendableNotificaton
+    public static class SendableNotificaton
     {
         /// <summary>
         /// The host notifies the device that it's about to start the backup.
         /// </summary>
-        SyncWillStart = 0,
+        public static string SyncWillStart => "com.apple.itunes-mobdev.syncWillStart";
         /// <summary>
         /// The host notifies the device that the backup has started.
         /// </summary>
-        SyncDidStart,
+        public static string SyncDidStart => "com.apple.itunes-mobdev.syncDidStart";
         /// <summary>
         /// The host notifies the device that the backup has finished.
         /// </summary>
-        SyncDidFinish,
+        public static string SyncDidFinish => "com.apple.itunes-mobdev.syncDidFinish";
         /// <summary>
         /// The host notifies the device about the lock request.
         /// </summary>
-        SyncLockRequest
+        public static string SyncLockRequest => "com.apple.itunes-mobdev.syncLockRequest";
     }
 }


### PR DESCRIPTION
Changes the way you register for notifications from NotificationProxy to only require a string now rather than the specific enum value, while still providing some pre-existing notifications as string values in case you want to use those.

Also adds async options to registering and posting notification proxy messages and changing internal uses to these.

Will then resolve #87 