### PR TITLE
Prevent unecessay directory creation

### DIFF
--- a/Netimobiledevice/Lockdown/LockdownClient.cs
+++ b/Netimobiledevice/Lockdown/LockdownClient.cs
@@ -329,6 +329,9 @@ namespace Netimobiledevice.Lockdown
         private void WriteStorageFile(string filename, byte[] data)
         {
             if (_pairingRecordsCacheDirectory != null) {
+                if (!_pairingRecordsCacheDirectory.Exists) {
+                    _pairingRecordsCacheDirectory.Create();
+                }
                 string file = Path.Combine(_pairingRecordsCacheDirectory.FullName, filename);
                 File.WriteAllBytes(file, data);
             }

--- a/Netimobiledevice/Lockdown/Pairing/PairRecords.cs
+++ b/Netimobiledevice/Lockdown/Pairing/PairRecords.cs
@@ -43,7 +43,7 @@ namespace Netimobiledevice.Lockdown.Pairing
         public static DirectoryInfo? GetPairingRecordsCacheFolder(string pairingRecordsCacheFolder = "")
         {
             if (string.IsNullOrEmpty(pairingRecordsCacheFolder)) {
-                pairingRecordsCacheFolder = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Netimobiledevice");
+                return null;
             }
             return new DirectoryInfo(pairingRecordsCacheFolder);
         }

--- a/Netimobiledevice/Lockdown/Pairing/PairRecords.cs
+++ b/Netimobiledevice/Lockdown/Pairing/PairRecords.cs
@@ -40,16 +40,10 @@ namespace Netimobiledevice.Lockdown.Pairing
             return null;
         }
 
-        public static DirectoryInfo? CreatePairingRecordsCacheFolder(string pairingRecordsCacheFolder = "")
+        public static DirectoryInfo? GetPairingRecordsCacheFolder(string pairingRecordsCacheFolder = "")
         {
             if (string.IsNullOrEmpty(pairingRecordsCacheFolder)) {
                 pairingRecordsCacheFolder = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Netimobiledevice");
-            }
-            try {
-                Directory.CreateDirectory(pairingRecordsCacheFolder);
-            }
-            catch (Exception) {
-                return null;
             }
             return new DirectoryInfo(pairingRecordsCacheFolder);
         }

--- a/Netimobiledevice/Lockdown/PlistUsbmuxLockdownClient.cs
+++ b/Netimobiledevice/Lockdown/PlistUsbmuxLockdownClient.cs
@@ -46,7 +46,7 @@ namespace Netimobiledevice.Lockdown
             ushort port = SERVICE_PORT, string usbmuxAddress = "", ILogger? logger = null)
         {
             string hostId = PairRecords.GenerateHostId(localHostname);
-            DirectoryInfo? pairingRecordsCacheDirectory = PairRecords.CreatePairingRecordsCacheFolder(pairingRecordsCacheFolder);
+            DirectoryInfo? pairingRecordsCacheDirectory = PairRecords.GetPairingRecordsCacheFolder(pairingRecordsCacheFolder);
 
             PlistUsbmuxLockdownClient lockdownClient = new(service, hostId: hostId, identifier: identifier, label: label, systemBuid: systemBuid, pairRecord: pairRecord,
                 pairingRecordsCacheDirectory: pairingRecordsCacheDirectory, port: port, usbmuxAddress: usbmuxAddress, logger: logger);

--- a/Netimobiledevice/Lockdown/RemoteLockdownClient.cs
+++ b/Netimobiledevice/Lockdown/RemoteLockdownClient.cs
@@ -51,7 +51,7 @@ namespace Netimobiledevice.Lockdown
             ushort port = SERVICE_PORT, ILogger? logger = null)
         {
             string hostId = PairRecords.GenerateHostId(localHostname);
-            DirectoryInfo? pairingRecordsCacheDirectory = PairRecords.CreatePairingRecordsCacheFolder(pairingRecordsCacheFolder);
+            DirectoryInfo? pairingRecordsCacheDirectory = PairRecords.GetPairingRecordsCacheFolder(pairingRecordsCacheFolder);
 
             RemoteLockdownClient lockdownClient = new(service, hostId: hostId, identifier: identifier, label: label, systemBuid: systemBuid, pairRecord: pairRecord,
                 pairingRecordsCacheDirectory: pairingRecordsCacheDirectory, port: port, logger: logger);

--- a/Netimobiledevice/Lockdown/TcpLockdownClient.cs
+++ b/Netimobiledevice/Lockdown/TcpLockdownClient.cs
@@ -42,7 +42,7 @@ namespace Netimobiledevice.Lockdown
             ushort port = SERVICE_PORT, ILogger? logger = null)
         {
             string hostId = PairRecords.GenerateHostId(localHostname);
-            DirectoryInfo? pairingRecordsCacheDirectory = PairRecords.CreatePairingRecordsCacheFolder(pairingRecordsCacheFolder);
+            DirectoryInfo? pairingRecordsCacheDirectory = PairRecords.GetPairingRecordsCacheFolder(pairingRecordsCacheFolder);
 
             TcpLockdownClient lockdownClient = new(service, hostId: hostId, hostname: hostname, identifier: identifier, label: label, systemBuid: systemBuid, pairRecord: pairRecord,
                 pairingRecordsCacheDirectory: pairingRecordsCacheDirectory, port: port, logger: logger);

--- a/Netimobiledevice/Lockdown/UsbmuxLockdownClient.cs
+++ b/Netimobiledevice/Lockdown/UsbmuxLockdownClient.cs
@@ -42,7 +42,7 @@ namespace Netimobiledevice.Lockdown
             ushort port = SERVICE_PORT, string usbmuxAddress = "", ILogger? logger = null)
         {
             string hostId = PairRecords.GenerateHostId(localHostname);
-            DirectoryInfo? pairingRecordsCacheDirectory = PairRecords.CreatePairingRecordsCacheFolder(pairingRecordsCacheFolder);
+            DirectoryInfo? pairingRecordsCacheDirectory = PairRecords.GetPairingRecordsCacheFolder(pairingRecordsCacheFolder);
 
             UsbmuxLockdownClient lockdownClient = new(service, hostId: hostId, identifier: identifier, label: label, systemBuid: systemBuid, pairRecord: pairRecord,
                 pairingRecordsCacheDirectory: pairingRecordsCacheDirectory, port: port, usbmuxAddress: usbmuxAddress, logger: logger);

--- a/Netimobiledevice/Netimobiledevice.csproj
+++ b/Netimobiledevice/Netimobiledevice.csproj
@@ -22,7 +22,7 @@
 		<RepositoryUrl>https://github.com/artehe/Netimobiledevice</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<Title>$(AssemblyName)</Title>
-		<Version>2.5.0</Version>
+		<Version>2.5.1</Version>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This should prevent the "Netimobiledevice" pairing cache directory being created unnecessarily when it is not actively being used.