### PR TITLE
Fix the max read size for afc service to be 1 MiB

### DIFF
--- a/Netimobiledevice/Afc/AfcService.cs
+++ b/Netimobiledevice/Afc/AfcService.cs
@@ -21,7 +21,7 @@ namespace Netimobiledevice.Afc
         private const string LOCKDOWN_SERVICE_NAME = "com.apple.afc";
         private const string RSD_SERVICE_NAME = "com.apple.afc.shim.remote";
 
-        private const int MAXIMUM_READ_SIZE = 1024 ^ 2; // 1 MB
+        private const int MAXIMUM_READ_SIZE = 1024 * 1024; // 1 MB
 
         private static string[] DirectoryTraversalFiles { get; } = [".", "..", ""];
 


### PR DESCRIPTION
Dunno how I missed this.... but should resolve #105 

Have changed the max read size to be the value it should have been originally 1MiB rather than the current value of 1026 bytes.