### PR TITLE
Use NetWintun

### DIFF
--- a/Netimobiledevice/Netimobiledevice.csproj
+++ b/Netimobiledevice/Netimobiledevice.csproj
@@ -22,7 +22,7 @@
 		<RepositoryUrl>https://github.com/artehe/Netimobiledevice</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<Title>$(AssemblyName)</Title>
-		<Version>2.6.0</Version>
+		<Version>2.6.1</Version>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -36,7 +36,7 @@
 	
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
-		<PackageReference Include="Unofficial.WinTun" Version="0.14.1.3" />
+		<PackageReference Include="NetWintun" Version="0.0.1-13" />
 		<PackageReference Include="Zeroconf" Version="3.7.16" />
 	</ItemGroup>
 </Project>

--- a/Netimobiledevice/Netimobiledevice.csproj
+++ b/Netimobiledevice/Netimobiledevice.csproj
@@ -22,7 +22,7 @@
 		<RepositoryUrl>https://github.com/artehe/Netimobiledevice</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<Title>$(AssemblyName)</Title>
-		<Version>2.6.1</Version>
+		<Version>2.6.2</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Netimobiledevice/Netimobiledevice.csproj
+++ b/Netimobiledevice/Netimobiledevice.csproj
@@ -22,7 +22,7 @@
 		<RepositoryUrl>https://github.com/artehe/Netimobiledevice</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<Title>$(AssemblyName)</Title>
-		<Version>2.6.2</Version>
+		<Version>2.6.0</Version>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -36,7 +36,7 @@
 	
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
-		<PackageReference Include="NetWintun" Version="0.0.1-13" />
+		<PackageReference Include="NetWintun" Version="1.0.1" />
 		<PackageReference Include="Zeroconf" Version="3.7.16" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
- Move from `Unofficial.Wintun` package to `NetWintun` package.
- Make use of `NetWintun`'s async feature to improve the receiving of async reads.

## Motivation

Currently the Netimobile device project uses [Unoffical.Wintun](https://www.nuget.org/packages/Unofficial.WinTun).
This project is not licenced, and so causes a problem for consumers of `Netimobiledevice`, as they are in a legal grey area when it comes to permissions to use/distribute `Unofficial.Wintun` in their own packages. 

I have [tried](https://github.com/akarincli/Unofficial.WinTun/issues/1) to get the repo owner to commit using a licence but the discussion fizzled out.

Wintun is fairly trivial, so I've spent some time making an alternative: [NetWintun](https://github.com/aneilmac/Netwintun) to solve this problem. It has some enhancements over the old API such as async/await calls to receive (which is something that other wrappers do not offer.)

Feel free to reject this PR if you'd prefer to use a different flavour of `Wintun`. But I'd urge to move away from `Unoffical.Wintun` due to the licensing problem.

Yours,
aneilmac


