### PR TITLE
Enable dependabot for weekly checks.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "dotnet-sdk" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "dotnet-sdk"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
It may be worth enabling the [dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) action in GitHub, such that any version updates to downstream packages are automatically PR'd, freeing the maintainer from manually having to check for version updates. I've copied the basic template and added a check for dotnet, and a check for github actions. I don't think there's anything else that needs done.

Ideally, this PR should be accepted after https://github.com/artehe/Netimobiledevice/pull/118 (if either is accepted.)