### PR TITLE
Reduce warning noise.

### DIFF
--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -1,0 +1,6 @@
+<Project>
+    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <WarningsNotAsErrors>CS0067;CS8602;CS0649;CS0108;CS8603;CS0169;CS0414;CS8618;IL2026;IL2091</WarningsNotAsErrors>
+    </PropertyGroup>
+</Project>

--- a/Netimobiledevice/Remoted/Frames/ContinuationFrame.cs
+++ b/Netimobiledevice/Remoted/Frames/ContinuationFrame.cs
@@ -30,11 +30,7 @@ namespace Netimobiledevice.Remoted.Frames
 
         public override string ToString()
         {
-            return string.Format("[Frame: CONTINUATION, Id={0}, EndStream={1}, EndHeaders={2}, HeaderBlockFragmentLength={3}]",
-                StreamIdentifier,
-                IsEndStream,
-                EndHeaders,
-                HeaderBlockFragment.Length);
+            return $"[Frame: CONTINUATION, Id={StreamIdentifier}, EndStream={IsEndStream}, EndHeaders={EndHeaders}, HeaderBlockFragmentLength={HeaderBlockFragment.Length}]";
         }
 
     }

--- a/Netimobiledevice/Remoted/Frames/DataFrame.cs
+++ b/Netimobiledevice/Remoted/Frames/DataFrame.cs
@@ -77,11 +77,6 @@ namespace Netimobiledevice.Remoted.Frames
             Array.Copy(payloadData, index, Data, 0, Data.Length);
         }
 
-        public override string ToString() => string.Format("[Frame: DATA, Id={0}, EndStream={1}, Padded={2}, PadLength={3}, PayloadLength={4}]",
-                StreamIdentifier,
-                IsEndStream,
-                Padded,
-                PadLength,
-                PayloadLength);
+        public override string ToString() => $"[Frame: DATA, Id={StreamIdentifier}, EndStream={IsEndStream}, Padded={Padded}, PadLength={PadLength}, PayloadLength={PayloadLength}]";
     }
 }

--- a/Netimobiledevice/Remoted/Frames/Frame.cs
+++ b/Netimobiledevice/Remoted/Frames/Frame.cs
@@ -157,6 +157,6 @@ namespace Netimobiledevice.Remoted.Frames
 
         public abstract void ParsePayload(byte[] payloadData, FrameHeader frameHeader);
 
-        public override string ToString() => string.Format("[Frame: {0}, Id={1}, Flags={2}, PayloadLength={3}, IsEndStream={4}]", Type.ToString().ToUpperInvariant(), StreamIdentifier, Flags, PayloadLength, IsEndStream);
+        public override string ToString() => $"[Frame: {Type.ToString().ToUpperInvariant()}, Id={StreamIdentifier}, Flags={Flags}, PayloadLength={PayloadLength}, IsEndStream={IsEndStream}]";
     }
 }

--- a/Netimobiledevice/Remoted/Frames/GoAwayFrame.cs
+++ b/Netimobiledevice/Remoted/Frames/GoAwayFrame.cs
@@ -53,11 +53,7 @@ namespace Netimobiledevice.Remoted.Frames
                 debug = System.Text.Encoding.ASCII.GetString(AdditionalDebugData);
             }
 
-            return string.Format("[Frame: GOAWAY, Id={0}, ErrorCode={1}, LastStreamId={2}, AdditionalDebugData={3}]",
-                StreamIdentifier,
-                ErrorCode,
-                LastStreamId,
-                debug);
+            return $"[Frame: GOAWAY, Id={StreamIdentifier}, ErrorCode={ErrorCode}, LastStreamId={LastStreamId}, AdditionalDebugData={debug}]";
         }
     }
 }

--- a/Netimobiledevice/Remoted/Frames/HeadersFrame.cs
+++ b/Netimobiledevice/Remoted/Frames/HeadersFrame.cs
@@ -132,14 +132,6 @@ namespace Netimobiledevice.Remoted.Frames
             // Don't care about padding
         }
 
-        public override string ToString() => string.Format("[Frame: HEADERS, Id={0}, EndStream={1}, EndHeaders={2}, Priority={3}, Weight={4}, Padded={5}, PadLength={6}, HeaderBlockFragmentLength={7}]",
-                StreamIdentifier,
-                IsEndStream,
-                EndHeaders,
-                Priority,
-                Weight,
-                Padded,
-                PadLength,
-                HeaderBlockFragment.Length);
+        public override string ToString() => $"[Frame: HEADERS, Id={StreamIdentifier}, EndStream={IsEndStream}, EndHeaders={EndHeaders}, Priority={Priority}, Weight={Weight}, Padded={Padded}, PadLength={PadLength}, HeaderBlockFragmentLength={HeaderBlockFragment.Length}]";
     }
 }

--- a/Netimobiledevice/Remoted/Frames/PingFrame.cs
+++ b/Netimobiledevice/Remoted/Frames/PingFrame.cs
@@ -36,9 +36,6 @@ namespace Netimobiledevice.Remoted.Frames
             }
         }
 
-        public override string ToString() => string.Format("[Frame: PING, Id={0}, Ack={1}, OpaqueData={2}]",
-                StreamIdentifier,
-                Ack,
-                OpaqueData.Length);
+        public override string ToString() => $"[Frame: PING, Id={StreamIdentifier}, Ack={Ack}, OpaqueData={OpaqueData.Length}]";
     }
 }

--- a/Netimobiledevice/Remoted/Frames/PriorityFrame.cs
+++ b/Netimobiledevice/Remoted/Frames/PriorityFrame.cs
@@ -54,9 +54,6 @@ namespace Netimobiledevice.Remoted.Frames
             _weight = payloadData[4];
         }
 
-        public override string ToString() => string.Format("[Frame: PRIORITY, Id={0}, StreamDependency={1}, Weight={2}]",
-                StreamIdentifier,
-                StreamDependency,
-                Weight);
+        public override string ToString() => $"[Frame: PRIORITY, Id={StreamIdentifier}, StreamDependency={StreamDependency}, Weight={Weight}]";
     }
 }

--- a/Netimobiledevice/Remoted/Frames/PushPromiseFrame.cs
+++ b/Netimobiledevice/Remoted/Frames/PushPromiseFrame.cs
@@ -99,13 +99,6 @@ namespace Netimobiledevice.Remoted.Frames
             // Don't care about padding
         }
 
-        public override string ToString() => string.Format("[Frame: PUSH_PROMISE, Id={0}, EndStream={1}, EndHeaders={2}, StreamDependency={3}, Padded={4}, PadLength={5}, HeaderBlockFragmentLength={6}]",
-                StreamIdentifier,
-                IsEndStream,
-                EndHeaders,
-                StreamDependency,
-                Padded,
-                PadLength,
-                HeaderBlockFragment.Length);
+        public override string ToString() => $"[Frame: PUSH_PROMISE, Id={StreamIdentifier}, EndStream={IsEndStream}, EndHeaders={EndHeaders}, StreamDependency={StreamDependency}, Padded={Padded}, PadLength={PadLength}, HeaderBlockFragmentLength={HeaderBlockFragment.Length}]";
     }
 }

--- a/Netimobiledevice/Remoted/Frames/RstStreamFrame.cs
+++ b/Netimobiledevice/Remoted/Frames/RstStreamFrame.cs
@@ -37,8 +37,6 @@ namespace Netimobiledevice.Remoted.Frames
             }
         }
 
-        public override string ToString() => string.Format("[Frame: RST_STREAM, Id={0}, ErrorCode={1}]",
-                StreamIdentifier,
-                ErrorCode);
+        public override string ToString() => $"[Frame: RST_STREAM, Id={StreamIdentifier}, ErrorCode={ErrorCode}]";
     }
 }

--- a/Netimobiledevice/Remoted/Frames/SettingsFrame.cs
+++ b/Netimobiledevice/Remoted/Frames/SettingsFrame.cs
@@ -89,15 +89,7 @@ namespace Netimobiledevice.Remoted.Frames
 
         public override string ToString()
         {
-            return string.Format("[Frame: SETTINGS, Id={0}, Ack={1}, HeaderTableSize={2}, EnablePush={3}, MaxConcurrentStreams={4}, InitialWindowSize={5}, MaxFrameSize={6}, MaxHeaderListSize={7}]",
-                StreamIdentifier,
-                Ack,
-                HeaderTableSize,
-                EnablePush,
-                MaxConcurrentStreams,
-                InitialWindowSize,
-                MaxFrameSize,
-                MaxHeaderListSize);
+            return $"[Frame: SETTINGS, Id={StreamIdentifier}, Ack={Ack}, HeaderTableSize={HeaderTableSize}, EnablePush={EnablePush}, MaxConcurrentStreams={MaxConcurrentStreams}, InitialWindowSize={InitialWindowSize}, MaxFrameSize={MaxFrameSize}, MaxHeaderListSize={MaxHeaderListSize}]";
         }
 
     }

--- a/Netimobiledevice/Remoted/Frames/WindowUpdateFrame.cs
+++ b/Netimobiledevice/Remoted/Frames/WindowUpdateFrame.cs
@@ -26,8 +26,6 @@ namespace Netimobiledevice.Remoted.Frames
             WindowSizeIncrement = ConvertFromUInt31(windowSizeIncrData.EnsureBigEndian());
         }
 
-        public override string ToString() => string.Format("[Frame: WINDOW_UPDATE, Id={0}, WindowSizeIncrement={1}]",
-                StreamIdentifier,
-                WindowSizeIncrement);
+        public override string ToString() => $"[Frame: WINDOW_UPDATE, Id={StreamIdentifier}, WindowSizeIncrement={WindowSizeIncrement}]";
     }
 }

--- a/Netimobiledevice/Remoted/Tunnel/RemotePairingProtocol.cs
+++ b/Netimobiledevice/Remoted/Tunnel/RemotePairingProtocol.cs
@@ -26,10 +26,7 @@ namespace Netimobiledevice.Remoted.Tunnel
             return await ReceiveResponse();
         }
 
-        public async Task Connect(bool autopair = true)
-        {
-            // TODO
-        }
+        public Task Connect(bool autopair = true) => Task.CompletedTask;
 
         public string RemoteDeviceModel => HandshakeInfo["peerDeviceInfo"]["model"].ToString();
     }

--- a/Netimobiledevice/Remoted/Tunnel/RemotePairingProtocol.cs
+++ b/Netimobiledevice/Remoted/Tunnel/RemotePairingProtocol.cs
@@ -26,7 +26,12 @@ namespace Netimobiledevice.Remoted.Tunnel
             return await ReceiveResponse();
         }
 
-        public Task Connect(bool autopair = true) => Task.CompletedTask;
+        public Task Connect(bool autopair = true)
+        {
+            // TODO
+            return Task.CompletedTask;
+            ;
+        }
 
         public string RemoteDeviceModel => HandshakeInfo["peerDeviceInfo"]["model"].ToString();
     }

--- a/NetimobiledeviceTest/EndianBitConversion/GetValueTests.cs
+++ b/NetimobiledeviceTest/EndianBitConversion/GetValueTests.cs
@@ -74,18 +74,18 @@ public class GetValueTests
             int outputSize)
     {
         // Null check
-        Assert.ThrowsException<ArgumentNullException>(() => machineEndianBitConverterMethod(null!, 0));
-        Assert.ThrowsException<ArgumentNullException>(() => otherEndianBitConverterMethod(null!, 0));
+        Assert.ThrowsExactly<ArgumentNullException>(() => machineEndianBitConverterMethod(null!, 0));
+        Assert.ThrowsExactly<ArgumentNullException>(() => otherEndianBitConverterMethod(null!, 0));
 
         // Negative index
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => machineEndianBitConverterMethod(new byte[8], -1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => otherEndianBitConverterMethod(new byte[8], -1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => machineEndianBitConverterMethod(new byte[8], -1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => otherEndianBitConverterMethod(new byte[8], -1));
 
         // Index + outputSize longer than byte array
         const int arrayLength = 16;
         int badStartIndex = arrayLength - outputSize + 1;
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => machineEndianBitConverterMethod(new byte[arrayLength], badStartIndex));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => otherEndianBitConverterMethod(new byte[arrayLength], badStartIndex));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => machineEndianBitConverterMethod(new byte[arrayLength], badStartIndex));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => otherEndianBitConverterMethod(new byte[arrayLength], badStartIndex));
     }
 
     [ClassInitialize()]

--- a/NetimobiledeviceTest/Plist/ArrayNodeTests.cs
+++ b/NetimobiledeviceTest/Plist/ArrayNodeTests.cs
@@ -19,7 +19,7 @@ public class ArrayNodeTests
         int indexToTry = property.Count;
 
         PropertyNode node;
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => node = property[indexToTry]);
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => node = property[indexToTry]);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Reduce existing warnings

This change partially deals with some of the warnings that are output when compiling the project.

- Fixes [MSTEST0039](https://learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0039)
- Fixes [CA1305](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1305)
- Fixes CS1998

I have not attempted to fix other warnings which may lead to behaviour changes, as it is unclear to me what the actual behaviour should be (especially in terms of, say, nullable expectations of some properties.)

Of particular note: I think [CS0108](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0108) reveals a legitimate bug and should be addressed soon.

## Warning management going forward

To handle warnings more effectively, I have enabled `WarningsAsErrors` repo-wide in `Directory.Build.Props`. 
  - This is only enabled in release mode, to not cause unnecessary churn during the course of development.
  - Existing warnings are kept as warnings via the `WarningsNotAsErrors` mechanism.
  - Any new kinds of warnings that may inadvertently enter the codebase will be treated as errors.

The intent is to be able to tackle the warnings on a type-by-type basis, such that we can reduce `WarningsNotAsErrors` one code at a time until it can be omitted.  

I hope this makes sense.

Kind regards,
aneilmac

