### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "dotnet-sdk"
+  - package-ecosystem: "nuget"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Sorry, I made a mistake. 😅 I forgot that `dotnet-sdk` is for the `globa.json` _only_ - which this repo doesn't have! Meant to update the nuget ecosystem.

Apologies for the churn.